### PR TITLE
Add per agent random socket addr allocation

### DIFF
--- a/pysipp/agent.py
+++ b/pysipp/agent.py
@@ -62,7 +62,7 @@ class UserAgent(command.SippCmd):
 
         # create and configure a temp scenario
         scen = plugin.mng.hook.pysipp_conf_scen_protocol(
-            agents=[self], confpy=None, defaults=None,
+            agents=[self], confpy=None, scenkwargs={},
         )
         # run the standard protocol
         # (attach allocted runner for reuse/post-portem)
@@ -377,7 +377,9 @@ class ScenarioType(object):
             copies.append(self.prepare_agent(agent))
         return copies
 
-    def from_agents(self, agents):
+    def from_agents(self, agents=None):
+        """Create a new scenario from prepared agents.
+        """
         return type(self)(
             self.prepare(agents), self._defaults, confpy=self.mod)
 

--- a/pysipp/agent.py
+++ b/pysipp/agent.py
@@ -196,7 +196,6 @@ _dd = {
     'global_vars': {},
 }
 _defaults = {
-    'local_host': '127.0.0.1',
     'recv_timeout': 5000,
     'call_count': 1,
     'rate': 1,

--- a/pysipp/hookspec.py
+++ b/pysipp/hookspec.py
@@ -35,7 +35,7 @@ def pysipp_load_scendir(path, xmls, confpy):
 
 
 @hookspec(firstresult=True)
-def pysipp_conf_scen_protocol(agents, confpy, defaults):
+def pysipp_conf_scen_protocol(agents, confpy, scenkwargs):
     """Performs scenario configuration by making multiple hook calls with
     surrounding logic for determining the sub-registration of of pysipp_conf.py
     modules. A scenario object must be returned.
@@ -49,7 +49,7 @@ def pysipp_order_agents(agents, clients, servers):
 
 
 @hookspec(firstresult=True)
-def pysipp_new_scen(agents, confpy, defaults):
+def pysipp_new_scen(agents, confpy, scenkwargs):
     """Instantiate a scenario object.
     A scenario must adhere to a simple protocol:
         - support a `name` attribute which uniquely identifies the scenario

--- a/pysipp/netplug.py
+++ b/pysipp/netplug.py
@@ -1,0 +1,39 @@
+"""
+auto-networking plugin
+"""
+import socket
+from pysipp import plugin
+
+
+def getsockaddr(host, family=socket.AF_INET, port=0, sockmod=socket):
+    """Retrieve a random socket address from the local OS by
+    binding to an ip, acquiring a random port and then
+    closing the socket and returning that address.
+
+    ..warning:: Obviously this is not guarateed to be an unused address
+        since we don't actually keep it bound, so there may be a race with
+        other processes acquiring the addr before our SIPp process re-binds.
+    """
+    for fam, stype, proto, _, sa in socket.getaddrinfo(
+        host, port, family, socket.SOCK_DGRAM, 0, socket.AI_PASSIVE,
+    ):
+        s = socket.socket(family, stype, proto)
+        s.bind(sa)
+        sockaddr = s.getsockname()[:2]
+        s.close()
+        return sockaddr
+
+    raise socket.error("getaddrinfo returned empty sequence")
+
+
+@plugin.hookimpl
+def pysipp_conf_scen(agents, scen):
+    """Allocate a random socket addresses from the local OS for
+    each agent in the scenario.
+    """
+    host = scen.defaults.local_host or socket.getfqdn()
+    for ua in scen.agents.values():
+        copy = scen.prepare_agent(ua)
+        if not copy.srcaddr:
+            ua.srcaddr = getsockaddr(host)
+            ua.mediaaddr = getsockaddr(host)

--- a/pysipp/netplug.py
+++ b/pysipp/netplug.py
@@ -34,6 +34,9 @@ def pysipp_conf_scen(agents, scen):
     host = scen.defaults.local_host or socket.getfqdn()
     for ua in scen.agents.values():
         copy = scen.prepare_agent(ua)
-        if not copy.srcaddr:
+
+        if not copy.local_port and not copy.local_host:
             ua.srcaddr = getsockaddr(host)
-            ua.mediaaddr = getsockaddr(host)
+
+            if not copy.media_port and not copy.media_addr:
+                ua.mediaaddr = getsockaddr(host)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,11 @@ def default_agents():
     return uas, uac
 
 
-@pytest.fixture
-def basic_scen():
+@pytest.fixture(
+    params=[True, False],
+    ids=lambda b: "autolocalsocks={}".format(b)
+)
+def basic_scen(request):
     """The most basic scenario instance
     """
-    return scenario()
+    return scenario(autolocalsocks=request.param)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -106,7 +106,7 @@ def test_failures(ua, retcode, kwargs, exc):
     assert len(list(runner.iterprocs())) == 0
     # tests transparency of the defaults config pipeline
     scen = plugin.mng.hook.pysipp_conf_scen_protocol(
-        agents=[ua], confpy=None, defaults=None)
+        agents=[ua], confpy=None, scenkwargs={})
     cmd = scen.prepare_agent(ua).render()
     assert cmd in cmds2procs
     assert len(cmds2procs) == 1


### PR DESCRIPTION
Add an automatic networking plugin module which includes a
`pysipp_conf_scen` hook for provisioning agents with random socket
addrs allocated from the system. 

I still need to add some tests for this...

@vodik @wdoekes any thoughts on the addr allocation? I realize it could be racy but figured it does the trick. 