### PR TITLE
Steps towards python3 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: python
+sudo: false
+dist: trusty
+
+cache:
+  - bundler
+  - pip
+
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - nightly
+  - pypy
+  - pypy3
+
+addons:
+  apt:
+    packages:
+      - libpcap-dev
+      - libsctp-dev
+      - libncurses5-dev
+      - libssl-dev
+      - libgsl0-dev
+
+install:
+  - pip install -e .
+  - pip install --upgrade pytest
+  - pip list
+
+before_script:
+  - git clone https://github.com/SIPp/sipp.git
+  - cd sipp
+  - autoreconf -vifs
+  - ./configure --with-gsl --with-openssl --with-pcap --with-rtpstream --with-sctp
+  - make -j2
+  - export PATH="$PWD:$PATH"
+  - cd ..
+
+script:
+  - python setup.py pytest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/pysipp/__init__.py
+++ b/pysipp/__init__.py
@@ -181,7 +181,7 @@ def pysipp_conf_scen(agents, scen):
         # point all clients to send requests to 'primary' server agent
         # if they aren't already
         servers_addr = scen.serverdefaults.get('srcaddr', ('127.0.0.1', 5060))
-        uas = scen.prepare_agent(scen.servers.values()[0])
+        uas = scen.prepare_agent(list(scen.servers.values())[0])
         scen.clientdefaults.setdefault('destaddr', uas.srcaddr or servers_addr)
 
     elif not scen.clientdefaults.proxyaddr:

--- a/pysipp/__init__.py
+++ b/pysipp/__init__.py
@@ -20,13 +20,9 @@ pysipp - a python wrapper for launching SIPp
 '''
 import sys
 from os.path import dirname
-from load import iter_scen_dirs
-import launch
-import report
-import plugin
-import netplug
-import agent
-from agent import client, server
+from . import launch, report, plugin, netplug, agent
+from .load import iter_scen_dirs
+from .agent import client, server
 
 
 class SIPpFailure(RuntimeError):

--- a/pysipp/agent.py
+++ b/pysipp/agent.py
@@ -8,9 +8,8 @@ from copy import deepcopy
 from distutils import spawn
 from collections import namedtuple, OrderedDict
 from itertools import repeat
-from . import command, plugin
+from . import command, plugin, utils
 import tempfile
-import utils
 
 log = utils.get_logger()
 

--- a/pysipp/command.py
+++ b/pysipp/command.py
@@ -4,7 +4,7 @@ Command string rendering
 import string
 import socket
 from collections import OrderedDict
-import utils
+from . import utils
 
 log = utils.get_logger()
 

--- a/pysipp/launch.py
+++ b/pysipp/launch.py
@@ -6,9 +6,9 @@ import os
 import shlex
 import select
 import threading
-import utils
 import signal
 import time
+from . import utils
 from pprint import pformat
 from collections import OrderedDict, namedtuple
 

--- a/pysipp/load.py
+++ b/pysipp/load.py
@@ -3,7 +3,7 @@ Load files from scenario directories
 """
 import glob
 import os
-import utils
+from . import utils
 log = utils.get_logger()
 
 

--- a/pysipp/plugin.py
+++ b/pysipp/plugin.py
@@ -2,8 +2,8 @@
 `pluggy` plugin and hook management
 '''
 import pluggy
-import hookspec
 import contextlib
+from . import hookspec
 
 hookimpl = pluggy.HookimplMarker('pysipp')
 mng = pluggy.PluginManager('pysipp', implprefix='pysipp')

--- a/pysipp/report.py
+++ b/pysipp/report.py
@@ -4,7 +4,7 @@ reporting for writing SIPp log files to the console
 import time
 from os import path
 from collections import OrderedDict
-import utils
+from . import utils
 
 log = utils.get_logger()
 

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,11 @@
 #
 # Authors : Tyler Goodlet
 
+import sys
 from setuptools import setup
 
 
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 with open('README.md') as f:
     readme = f.read()
 
@@ -38,9 +40,8 @@ setup(
     platforms=['linux'],
     packages=['pysipp'],
     install_requires=['pluggy==0.3.1'],
-    extras_require={
-        'testing': ['pytest'],
-    },
+    setup_requires=['pytest-runner'] if needs_pytest else [],
+    tests_require=['pytest'],
     # use_2to3 = False
     # zip_safe=True,
     classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def default_agents():
 
 @pytest.fixture(
     params=[True, False],
-    ids=lambda b: "autolocalsocks={}".format(b)
+    ids="autolocalsocks={}".format
 )
 def basic_scen(request):
     """The most basic scenario instance

--- a/tests/scens/default_with_confpy/pysipp_conf.py
+++ b/tests/scens/default_with_confpy/pysipp_conf.py
@@ -5,4 +5,4 @@ def pysipp_conf_scen(agents, scen):
 
 def pysipp_order_agents(agents, clients, servers):
     # should still work due to re-transmissions
-    return reversed(agents.values())
+    return reversed(list(agents.values()))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -126,16 +126,17 @@ def test_scenario():
     scen2 = agent.Scenario(agents)
 
     # verify contained agents
-    assert scen.agents.values() == agents == scen._agents
+    assert list(scen.agents.values()) == agents == scen._agents
     assert scen.prepare() != agents  # new copies
 
     # verify order
-    assert uas is scen.agents.values()[0]
-    assert uac is scen.agents.values()[1]
+    agents = list(scen.agents.values())
+    assert uas is agents[0]
+    assert uac is agents[1]
     # verify servers
-    assert uas is scen.servers.values()[0]
+    assert uas is list(scen.servers.values())[0]
     # verify clients
-    assert uac is scen.clients.values()[0]
+    assert uac is list(scen.clients.values())[0]
 
     # ensure defaults attr setting works
     doggy = 'doggy'

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -3,7 +3,6 @@ pysipp.agent module tests
 '''
 import pytest
 import tempfile
-import os
 import pysipp
 from pysipp import agent, launch, plugin
 
@@ -56,7 +55,7 @@ def test_scen_logdir():
     """Verify log file arguments when logdir is set using Scenario.defaults
     """
     scen = pysipp.scenario()
-    logdir = os.getcwd()
+    logdir = tempfile.mkdtemp(suffix='_pysipp')
     scen.defaults.logdir = logdir
     for ua in scen.prepare():
         check_log_files(ua, logdir)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -19,4 +19,4 @@ def test_iter_dirs(scendir):
     for path, xmls, confpy in iter_scen_dirs(scendir):
         expect = paths.get(os.path.basename(path), None)
         if expect:
-            assert map(bool, (xmls, confpy)) == expect
+            assert [bool(xmls), bool(confpy)] == expect

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -119,7 +119,7 @@ def test_hook_overrides(basic_scen):
 @pytest.mark.parametrize(
     "dictname",
     ['defaults', 'clientdefaults', 'serverdefaults'],
-    ids=lambda d: str(d),
+    ids=str,
 )
 @pytest.mark.parametrize(
     "data",

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -45,7 +45,7 @@ def test_confpy_hooks(scendir):
     path, scen = list(pysipp.walk(scendir + '/default_with_confpy'))[0]
     assert scen.mod
     # ordering hook should reversed agents
-    agents = scen.agents.values()
+    agents = list(scen.agents.values())
     assert agents[0].is_client()
     assert agents[1].is_server()
     # check that `scen.remote_host = 'doggy'` was applied

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# Tox (https://testrun.org/tox/latest/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34, py35, pypy
+
+[testenv]
+commands =
+	{envpython} setup.py pytest


### PR DESCRIPTION
Switch to proper relative imports so that the code will import, and then add tox for testing.

Major outstanding changes needed to support python3 seem to revolved around `values()` call, which under python3 are now views.