### PR TITLE
Add support for multiple '-inf' files

### DIFF
--- a/pysipp/command.py
+++ b/pysipp/command.py
@@ -71,6 +71,16 @@ class DictField(Field):
         )
 
 
+class ListField(Field):
+    _default = []
+
+    def render(self, value):
+        return ''.join(
+            self.fmtstr.format(**{self.name: "'{}'".format(val)})
+            for val in value
+        )
+
+
 def cmdstrtype(spec):
     '''Build a command str renderer from an iterable of format string tokens.
 
@@ -221,6 +231,7 @@ sipp_spec = [
     '-message_file {message_file} ',
     '-log_file {log_file} ',
     '-inf {info_file} ',
+    ('-inf {info_files} ', ListField),
     '-screen_file {screen_file} ',
     # bool flags
     ('-rtp_echo {rtp_echo}', BoolField),

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -55,6 +55,33 @@ def test_dict_field():
     assert '-key' not in cmd.render()
 
 
+def test_list_field():
+    cmd = SippCmd()
+    assert not isinstance(cmd.info_files, basestring)
+
+    # one entry
+    cmd.info_files = ["100"]
+    assert "-inf '100'" in cmd.render()
+
+    # two entries
+    cmd.info_files = ["100", "200"]
+    assert "-inf '100' -inf '200'" in cmd.render()
+
+    # clear all
+    del cmd.info_files[:]
+    assert '-inf' not in cmd.render()
+
+    # three entries - two via 'info_files' and one via 'info_file'
+    cmd.info_files = ["100", "200"]
+    cmd.info_file = "300"
+    assert "-inf '300' -inf '100' -inf '200'" in cmd.render()
+
+    # clear all
+    cmd.info_file = ""
+    cmd.info_files[:] = []
+    assert '-inf' not in cmd.render()
+
+
 def test_prefix():
     cmd = SippCmd()
     pre = "doggy bath"


### PR DESCRIPTION
Add ListField type.
Add 'info_files' which will accept a list of strings, each to be rendered as '-inf'.
Tested both 'info_file' and 'info_files' simoultaneously and both were effective.

Correlated with issue #26.