### PR TITLE
Fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: false
-dist: trusty
+dist: precise
 
 cache:
   - bundler
@@ -8,11 +8,11 @@ cache:
 
 python:
   - 2.7
-  - 3.4
   - 3.5
+  - 3.6
   - nightly
   - pypy
-  - pypy3
+  # - pypy3
 
 addons:
   apt:
@@ -31,11 +31,9 @@ install:
 before_script:
   - git clone https://github.com/SIPp/sipp.git
   - cd sipp
-  - autoreconf -vifs
-  - ./configure --with-gsl --with-openssl --with-pcap --with-rtpstream --with-sctp
-  - make -j2
+  - ./build.sh
   - export PATH="$PWD:$PATH"
   - cd ..
 
 script:
-  - python setup.py pytest
+  - pytest tests/

--- a/pysipp/__init__.py
+++ b/pysipp/__init__.py
@@ -217,7 +217,7 @@ def pysipp_run_protocol(scen, runner, block, timeout, raise_exc):
         and perform error and logfile reporting.
         """
         cmds2procs = cmds2procs or runner.get(timeout=timeout)
-        agents2procs = zip(agents, cmds2procs.values())
+        agents2procs = list(zip(agents, cmds2procs.values()))
         msg = report.err_summary(agents2procs)
         if msg:
             # report logs and stderr

--- a/pysipp/netplug.py
+++ b/pysipp/netplug.py
@@ -35,11 +35,13 @@ def pysipp_conf_scen(agents, scen):
     for ua in scen.agents.values():
         copy = scen.prepare_agent(ua)
 
+        ip, port = getsockaddr(ua.local_host)
+
         if not copy.local_host:
-            ua.local_host = host
+            ua.local_host = ip
 
         if not copy.local_port:
-            ua.local_port = getsockaddr(ua.local_host)[1]
+            ua.local_port = port
 
         if not copy.media_addr:
             ua.media_addr = ua.local_host

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 # Authors : Tyler Goodlet
-
-import sys
 from setuptools import setup
 
 
-needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 with open('README.md') as f:
     readme = f.read()
 
@@ -40,10 +37,7 @@ setup(
     platforms=['linux'],
     packages=['pysipp'],
     install_requires=['pluggy==0.3.1'],
-    setup_requires=['pytest-runner'] if needs_pytest else [],
     tests_require=['pytest'],
-    # use_2to3 = False
-    # zip_safe=True,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -57,7 +57,7 @@ def test_dict_field():
 
 def test_list_field():
     cmd = SippCmd()
-    assert not isinstance(cmd.info_files, basestring)
+    assert cmd.info_files is None
 
     # one entry
     cmd.info_files = ["100"]

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, pypy
+envlist = py27, py35, py36, pypy
 
 [testenv]
+deps =
+    pytest
+    pdbpp
 commands =
-    {envpython} setup.py pytest
+    pytest tests/ {posargs}


### PR DESCRIPTION
Good lord... SIPp was crashing yet again due to cmd line args hehe.

I simplified the SIPp build slightly just using the base install and I dropped all the unecessary `pytest-runner` stuff; even `pytest` doesn't use it ;P

Oh and the `pypy` installs are wacked. See #24 discussion.