### PR TITLE
Fix sipp build. Test with default Trusty.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-sudo: false
-dist: precise
 
 cache:
   - bundler
@@ -29,9 +27,11 @@ install:
   - pip list
 
 before_script:
-  - git clone https://github.com/SIPp/sipp.git
-  - cd sipp
-  - ./build.sh --full
+  - wget https://github.com/SIPp/sipp/releases/download/v3.5.2/sipp-3.5.2.tar.gz
+  - tar -xvzf sipp-3.5.2.tar.gz
+  - cd sipp-3.5.2
+  - ./configure
+  - make
   - export PATH="$PWD:$PATH"
   - cd ..
 


### PR DESCRIPTION
@tgoodlet, I tried to find why tests were failing. I tried installing it following [docs instructions](https://sipp-wip.readthedocs.io/en/latest/installation.html#installing-sipp), and tests with Python 2 were successful. When researching why Python 3.5 did not work, I found a [Travis blog entry](https://blog.travis-ci.com/2017-08-31-trusty-as-default-status) about ending support for Precise, so I switch to Trusty (default) and tests ran well. Is Precise a requirement for you? If so, we could research more about it, but if it is not, I propose to change to Trusty.