### PR TITLE
Add `auth_username` in command sipp_spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ uas(block=False)  # returns a `pysipp.launch.PopenRunner` instance by default
 uac()  # run client synchronously
 ```
 
+## Authentication
+When using the `[authentication]` (sipp keyword)[https://sipp.readthedocs.io/en/latest/scenarios/keywords.html#authentication]
+in scenarios, providing the credentials can be done with the
+`auth_username` and `auth_password` arguments, for example:
+
+```python
+pysipp.client(auth_username='sipp', auth_password='sipp-pass')
+```
+
 ## Multiple Agents
 For multi-UA orchestrations we can use a `pysipp.scenario`.
 The scenario from above is the default agent configuration:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ uac()  # run client synchronously
 ```
 
 ## Authentication
-When using the `[authentication]` (sipp keyword)[https://sipp.readthedocs.io/en/latest/scenarios/keywords.html#authentication]
+When using the `[authentication]` [sipp keyword](https://sipp.readthedocs.io/en/latest/scenarios/keywords.html#authentication)
 in scenarios, providing the credentials can be done with the
 `auth_username` and `auth_password` arguments, for example:
 

--- a/pysipp/command.py
+++ b/pysipp/command.py
@@ -212,7 +212,7 @@ sipp_spec = [
     # SIP vars
     '-cid_str {cid_str} ',
     '-base_cseq {base_cseq} ',
-    '-au {auth_username}',
+    '-au {auth_username} ',
     '-ap {auth_password} ',
     # load settings
     '-r {rate} ',

--- a/pysipp/command.py
+++ b/pysipp/command.py
@@ -212,6 +212,7 @@ sipp_spec = [
     # SIP vars
     '-cid_str {cid_str} ',
     '-base_cseq {base_cseq} ',
+    '-au {auth_username}',
     '-ap {auth_password} ',
     # load settings
     '-r {rate} ',


### PR DESCRIPTION
Hello, does something like this make sense? 

at the moment the only way to configure the username for authentication is to use the `-s` service option
but there are cases that one may want these two to be different