### PR TITLE
Drop pypy from ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ python:
   - 2.7
   - 3.5
   - 3.6
+  # - 3.7
   - nightly
-  - pypy
+  # - pypy
   # - pypy3
 
 addons:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Python configuring and launching the infamous
 ## It doesn't try to
 
 - Auto-generate SIPp XML scripts like [sippy_cup](https://github.com/mojolingo/sippy_cup)
-  * we believe this is the wrong way to work around the problem of SIPp's shitty XML control language
+  * `pysipp` in no way tries to work around the problem of SIPp's awful
+    XML control language; your current scenario scripts are compatible!
 
 
 ## Basic Usage
@@ -175,7 +176,8 @@ pysipp.utils.log_to_stderr("DEBUG")
 ### Applying default settings
 For now see [#4](https://github.com/SIPp/pysipp/issues/4)
 
-More to come...
+## More to come?
+- document attributes / flags
 - writing plugins
 - using a `pysipp_conf.py`
 - remote execution


### PR DESCRIPTION
To get things moving on a variety of PRs and so we can get an initial release out for #42. 

We'll address `pypy` problems down the road *if* there's a need.
Created #51 as a reminder.