### PR TITLE
Add test for proxy_host/proxy_port bug

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -90,17 +90,17 @@ def test_prefix():
     assert cmd.render() == "'{}'".format(pre) + " "
 
 
-def test_addr_field():
+@pytest.mark.parametrize(
+    "host, port, command",
+    [
+        (None, None, ""),
+        ("127.0.0.1", 5060, "-rsa '127.0.0.1':'5060' "),
+        ("::1", None, "-rsa '[::1]':'5060' "),
+        ("example.com", None, "-rsa 'example.com':'5060' "),
+    ],
+)
+def test_addr_field(host, port, command):
     cmd = SippCmd()
-    cmd.proxy_host = None
-    assert not cmd.render()
-
-    cmd.proxy_host = "127.0.0.1"
-    cmd.proxy_port = 5060
-    assert cmd.render() == "-rsa '127.0.0.1':'5060' "
-
-    cmd.proxy_host = "::1"
-    assert cmd.render() == "-rsa '[::1]':'5060' "
-
-    cmd.proxy_host = "example.com"
-    assert cmd.render() == "-rsa 'example.com':'5060' "
+    cmd.proxy_host = host
+    cmd.proxy_port = port
+    assert cmd.render() == command


### PR DESCRIPTION
Hello,
This test demonstrates how when using proxy_host
without also settings proxy_port can lead to a bug
cause of a missing space character at end of "-rsa"
in command `sipp_spec`.
For example if only `remote_host` is set to some
address '10.0.3.27' then sipp reports:
"Unknown remote host '10.0.3.27-sf'"

what should the approach be on solving this ?