### PR TITLE
Drop deprecated `implprefix=` usage.

### DIFF
--- a/pysipp/plugin.py
+++ b/pysipp/plugin.py
@@ -6,7 +6,7 @@ import contextlib
 from . import hookspec
 
 hookimpl = pluggy.HookimplMarker("pysipp")
-mng = pluggy.PluginManager("pysipp", implprefix="pysipp")
+mng = pluggy.PluginManager("pysipp")
 mng.add_hookspecs(hookspec)
 
 


### PR DESCRIPTION
Was trying to let a hopeful new contrib take this very simple change on but it seems i'm not explaining the change well?

See the details in #74.

Fixes #74.