### PR TITLE
fix tests after drop deprecated implprefix= usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     url="https://github.com/SIPp/pysipp",
     platforms=["linux"],
     packages=["pysipp", "pysipp.cli"],
-    install_requires=["pluggy>=0.11.0"],
+    install_requires=["pluggy>=1.0.0"],
     tests_require=["pytest"],
     entry_points={
         "console_scripts": ["sippfmt=pysipp.cli.sippfmt:main"],

--- a/tests/scens/default_with_confpy/pysipp_conf.py
+++ b/tests/scens/default_with_confpy/pysipp_conf.py
@@ -1,8 +1,15 @@
+import pluggy
+
+hookimpl = pluggy.HookimplMarker("pysipp")
+
+
+@hookimpl
 def pysipp_conf_scen(agents, scen):
     scen.uri_username = "doggy"
     agents["uac"].srcaddr = "127.0.0.1", 5070
 
 
+@hookimpl
 def pysipp_order_agents(agents, clients, servers):
     # should still work due to re-transmissions
     return reversed(list(agents.values()))

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -37,7 +37,6 @@ def test_collect(scenwalk):
     assert len(list(scenwalk())) == 1
 
 
-@pytest.mark.xfail
 def test_confpy_hooks(scendir):
     """Test that hooks included in a confpy file work
 


### PR DESCRIPTION
now the pysipp_conf.py has to use the pluggy.HookimplMarker("pysipp") decorator